### PR TITLE
refactor: `ChannelId` is now a `Channel` enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,6 +2987,7 @@ name = "midix"
 version = "2.0.0"
 dependencies = [
  "bevy",
+ "num_enum",
  "pretty_assertions",
  "thiserror 2.0.9",
 ]

--- a/midix/Cargo.toml
+++ b/midix/Cargo.toml
@@ -18,6 +18,7 @@ debug = ["bevy"]
 
 [dependencies]
 bevy = { version = "0.15", optional = true, default-features = false }
+num_enum = "0.7.3"
 thiserror = "2.0.9"
 
 [dev-dependencies]

--- a/midix/README.md
+++ b/midix/README.md
@@ -63,7 +63,7 @@ let VoiceEvent::NoteOn { key, velocity } = channel_voice_msg.event() else {
     panic!("Expected a note on event");
 };
 
-assert_eq!(channel_voice_msg.channel(), ChannelId::new(3).unwrap());
+assert_eq!(channel_voice_msg.channel(), Channel::Three);
 assert_eq!(key.note(), Note::C);
 assert_eq!(key.octave(), Octave::new(4));
 assert_eq!(velocity.byte().value(), 96);

--- a/midix/src/channel.rs
+++ b/midix/src/channel.rs
@@ -8,42 +8,49 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::message::{ChannelVoiceMessage, VoiceEvent};
 
-/// Identifies a channel for MIDI. Constructors check that the value is between 0-15.
+/// Identifies a channel for MIDI.
+///
+/// To get this channel from a `u8`, use [`Channel::try_from_primitive`].
 #[derive(
     Clone, Copy, PartialEq, Eq, Debug, Hash, IntoPrimitive, TryFromPrimitive, PartialOrd, Ord,
 )]
 #[repr(u8)]
 pub enum Channel {
+    /// 0bxxxx0000
     One = 0,
+    /// 0bxxxx0001
     Two,
+    /// 0bxxxx0010
     Three,
+    /// 0bxxxx0011
     Four,
+    /// 0bxxxx0100
     Five,
+    /// 0bxxxx0101
     Six,
+    /// 0bxxxx0110
     Seven,
+    /// 0bxxxx0111
     Eight,
+    /// 0bxxxx1000
     Nine,
+    /// 0bxxxx1001
     Ten,
+    /// 0bxxxx1010
     Eleven,
+    /// 0bxxxx1011
     Twelve,
+    /// 0bxxxx1100
     Thirteen,
+    /// 0bxxxx1101
     Fourteen,
+    /// 0bxxxx1110
     Fifteen,
+    /// 0bxxxx1111
     Sixteen,
 }
 
 impl Channel {
-    // /// Identify a channel (1, 2, 3)
-    // ///
-    // /// # Panics
-    // /// if the byte is 0
-    // ///
-    // /// # Errors
-    // /// If the channel is greater than a value of 15
-    // pub fn new(channel: u8) -> Result<Self, std::io::Error> {
-    //     Ok(Self(check_u4(channel - 1)?))
-    // }
-
     /// Send a voice event to this channel
     pub fn send_event(self, event: VoiceEvent) -> ChannelVoiceMessage {
         ChannelVoiceMessage::new(self, event)

--- a/midix/src/channel.rs
+++ b/midix/src/channel.rs
@@ -4,41 +4,49 @@
 
 use core::fmt;
 
-use crate::{
-    message::{ChannelVoiceMessage, VoiceEvent},
-    utils::check_u4,
-};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use crate::message::{ChannelVoiceMessage, VoiceEvent};
 
 /// Identifies a channel for MIDI. Constructors check that the value is between 0-15.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-pub struct ChannelId(u8);
+#[derive(
+    Clone, Copy, PartialEq, Eq, Debug, Hash, IntoPrimitive, TryFromPrimitive, PartialOrd, Ord,
+)]
+#[repr(u8)]
+pub enum Channel {
+    One = 0,
+    Two,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+    Eight,
+    Nine,
+    Ten,
+    Eleven,
+    Twelve,
+    Thirteen,
+    Fourteen,
+    Fifteen,
+    Sixteen,
+}
 
-impl ChannelId {
-    /// Identify a channel (1, 2, 3)
-    ///
-    /// # Panics
-    /// if the byte is 0
-    ///
-    /// # Errors
-    /// If the channel is greater than a value of 15
-    pub fn new(channel: u8) -> Result<Self, std::io::Error> {
-        Ok(Self(check_u4(channel - 1)?))
-    }
+impl Channel {
+    // /// Identify a channel (1, 2, 3)
+    // ///
+    // /// # Panics
+    // /// if the byte is 0
+    // ///
+    // /// # Errors
+    // /// If the channel is greater than a value of 15
+    // pub fn new(channel: u8) -> Result<Self, std::io::Error> {
+    //     Ok(Self(check_u4(channel - 1)?))
+    // }
 
     /// Send a voice event to this channel
     pub fn send_event(self, event: VoiceEvent) -> ChannelVoiceMessage {
         ChannelVoiceMessage::new(self, event)
-    }
-    /// returns 1-16
-    pub fn value(&self) -> u8 {
-        self.0 + 1
-    }
-
-    /// Identify a channel (0, 1, 2)
-    ///
-    /// Does not check for correctness
-    pub fn new_unchecked(channel: u8) -> Self {
-        Self(channel)
     }
 
     /// Given a status byte from some [`ChannelVoiceMessage`], perform bitwise ops
@@ -46,18 +54,27 @@ impl ChannelId {
     #[must_use]
     pub fn from_status(status: u8) -> Self {
         let channel = status & 0b0000_1111;
-        Self(channel)
+        Channel::try_from(channel).unwrap()
     }
 
     /// Returns the 4-bit channel number (0-15)
     #[must_use]
-    pub fn byte(&self) -> &u8 {
-        &self.0
+    pub fn to_byte(&self) -> u8 {
+        (*self).into()
     }
 }
 
-impl fmt::Display for ChannelId {
+impl fmt::Display for Channel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (self.0 + 1).fmt(f)
+        let res: u8 = (*self).into();
+        res.fmt(f)
     }
+}
+
+#[test]
+fn channel_from_status() {
+    use pretty_assertions::assert_eq;
+    assert_eq!(Channel::Eight, Channel::from_status(0b1011_0111));
+    assert_eq!(Channel::One, Channel::from_status(0b1011_0000));
+    assert_eq!(Channel::Sixteen, Channel::from_status(0b0101_1111));
 }

--- a/midix/src/events/live.rs
+++ b/midix/src/events/live.rs
@@ -139,7 +139,7 @@ fn parse_note_on() {
     assert_eq!(
         parsed,
         LiveEvent::ChannelVoice(ChannelVoiceMessage::new(
-            Channel::new(2).unwrap(),
+            Channel::Two,
             VoiceEvent::NoteOn {
                 key: Key::new(72).unwrap(),
                 velocity: Velocity::new(33).unwrap()

--- a/midix/src/events/live.rs
+++ b/midix/src/events/live.rs
@@ -139,7 +139,7 @@ fn parse_note_on() {
     assert_eq!(
         parsed,
         LiveEvent::ChannelVoice(ChannelVoiceMessage::new(
-            ChannelId::new(2).unwrap(),
+            Channel::new(2).unwrap(),
             VoiceEvent::NoteOn {
                 key: Key::new(72).unwrap(),
                 velocity: Velocity::new(33).unwrap()

--- a/midix/src/file/track.rs
+++ b/midix/src/file/track.rs
@@ -1,5 +1,5 @@
 use crate::{
-    channel::ChannelId,
+    channel::Channel,
     events::LiveEvent,
     prelude::{BytesText, Tempo, TimeSignature, TrackEvent, TrackMessage},
 };
@@ -74,7 +74,7 @@ pub struct TrackInfo<'a> {
     pub name: Option<BytesText<'a>>,
     pub device: Option<BytesText<'a>>,
     pub track_info: Option<u16>,
-    pub channel: Option<ChannelId>,
+    pub channel: Option<Channel>,
     pub tempo: Tempo,
 }
 

--- a/midix/src/file_repr/meta/mod.rs
+++ b/midix/src/file_repr/meta/mod.rs
@@ -38,7 +38,7 @@ pub enum MetaMessage<'a> {
     /// Name of the device that this file was intended to be played with.
     DeviceName(BytesText<'a>),
     /// Number of the MIDI channel that this file was intended to be played with.
-    MidiChannel(ChannelId),
+    MidiChannel(Channel),
     /// Number of the MIDI port that this file was intended to be played with.
     MidiPort(u8),
     /// Obligatory at track end.
@@ -98,7 +98,7 @@ impl<'a> MetaMessage<'a> {
                     ));
                 }
                 let c = data.first().unwrap();
-                MetaMessage::MidiChannel(ChannelId::new(*c + 1)?)
+                MetaMessage::MidiChannel(Channel::new(*c + 1)?)
             }
             0x21 => {
                 if data.len() != 1 {

--- a/midix/src/file_repr/meta/mod.rs
+++ b/midix/src/file_repr/meta/mod.rs
@@ -3,6 +3,7 @@ Contains types that deal with file ['MetaMessage']s
 "#]
 
 mod tempo;
+use num_enum::TryFromPrimitive;
 pub use tempo::*;
 mod time_signature;
 pub use time_signature::*;
@@ -97,8 +98,9 @@ impl<'a> MetaMessage<'a> {
                         ),
                     ));
                 }
+                //TODO: need to test thsi
                 let c = data.first().unwrap();
-                MetaMessage::MidiChannel(Channel::new(*c + 1)?)
+                MetaMessage::MidiChannel(Channel::try_from_primitive(*c)?)
             }
             0x21 => {
                 if data.len() != 1 {

--- a/midix/src/message/channel/voice.rs
+++ b/midix/src/message/channel/voice.rs
@@ -19,7 +19,7 @@ pub struct ChannelVoiceMessage {
 impl ChannelVoiceMessage {
     /// Create a new channel voice event from the channel and associated event type
     pub fn new(channel: Channel, message: VoiceEvent) -> Self {
-        let status = *channel.to_byte() | (message.status_nibble() << 4);
+        let status = channel.to_byte() | (message.status_nibble() << 4);
         Self {
             status: StatusByte::new_unchecked(status),
             message,

--- a/midix/src/message/channel/voice.rs
+++ b/midix/src/message/channel/voice.rs
@@ -18,8 +18,8 @@ pub struct ChannelVoiceMessage {
 
 impl ChannelVoiceMessage {
     /// Create a new channel voice event from the channel and associated event type
-    pub fn new(channel: ChannelId, message: VoiceEvent) -> Self {
-        let status = *channel.byte() | (message.status_nibble() << 4);
+    pub fn new(channel: Channel, message: VoiceEvent) -> Self {
+        let status = *channel.to_byte() | (message.status_nibble() << 4);
         Self {
             status: StatusByte::new_unchecked(status),
             message,
@@ -81,8 +81,8 @@ impl ChannelVoiceMessage {
     }
 
     /// Get the channel for the event
-    pub fn channel(&self) -> ChannelId {
-        ChannelId::from_status(self.status.byte())
+    pub fn channel(&self) -> Channel {
+        Channel::from_status(self.status.byte())
     }
 
     /// Returns true if the note is on. This excludes note on where the velocity is zero.

--- a/midix/src/message/channel/voice_event.rs
+++ b/midix/src/message/channel/voice_event.rs
@@ -66,7 +66,7 @@ impl VoiceEvent {
     }
 
     /// Turn self into a ChannelVoiceMessage
-    pub fn send_to_channel(self, channel: ChannelId) -> ChannelVoiceMessage {
+    pub fn send_to_channel(self, channel: Channel) -> ChannelVoiceMessage {
         ChannelVoiceMessage::new(channel, self)
     }
 

--- a/midix/src/reader/error.rs
+++ b/midix/src/reader/error.rs
@@ -1,3 +1,4 @@
+use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
 use std::{
     fmt,
     io::{self, ErrorKind},
@@ -42,6 +43,14 @@ impl ReaderError {
     /// Create a new out of bounds error
     pub fn oob(msg: impl fmt::Display) -> Self {
         Self::OutOfBounds(msg.to_string())
+    }
+}
+
+impl<T: TryFromPrimitive> From<TryFromPrimitiveError<T>> for ReaderError {
+    fn from(value: TryFromPrimitiveError<T>) -> Self {
+        // probably better way to handle this error. Please file
+        // an issue if you have a suggestion!
+        Self::oob(format!("{:?}", value))
     }
 }
 

--- a/midix/src/utils.rs
+++ b/midix/src/utils.rs
@@ -1,13 +1,7 @@
 use std::io::ErrorKind;
 
-pub fn check_u7(byte: u8) -> Result<u8, std::io::Error> {
+pub(crate) fn check_u7(byte: u8) -> Result<u8, std::io::Error> {
     (byte & 0b1000_0000 == 0)
-        .then_some(byte)
-        .ok_or(io_error!(ErrorKind::InvalidData, "Leading bit found"))
-}
-
-pub fn check_u4(byte: u8) -> Result<u8, std::io::Error> {
-    (byte & 0b1111_0000 == 0)
         .then_some(byte)
         .ok_or(io_error!(ErrorKind::InvalidData, "Leading bit found"))
 }

--- a/midix/tests/simple_midi/main.rs
+++ b/midix/tests/simple_midi/main.rs
@@ -1,4 +1,5 @@
 use midix::prelude::*;
+use num_enum::TryFromPrimitive;
 mod parsed;
 #[test]
 fn midi_file_ref() {
@@ -47,7 +48,7 @@ fn midi_file_ref() {
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), Channel::new(1).unwrap());
+    assert_eq!(cv.channel(), Channel::One);
     let VoiceEvent::ProgramChange { program } = cv.event() else {
         panic!();
     };
@@ -62,7 +63,7 @@ fn midi_file_ref() {
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), Channel::new(2).unwrap());
+    assert_eq!(cv.channel(), Channel::Two);
     let VoiceEvent::ProgramChange { program } = cv.event() else {
         panic!();
     };
@@ -77,7 +78,7 @@ fn midi_file_ref() {
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), Channel::new(3).unwrap());
+    assert_eq!(cv.channel(), Channel::Three);
     let VoiceEvent::ProgramChange { program } = cv.event() else {
         panic!();
     };
@@ -109,7 +110,10 @@ fn note_on(
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), Channel::new(channel_id).unwrap());
+    assert_eq!(
+        cv.channel(),
+        Channel::try_from_primitive(channel_id).unwrap()
+    );
     let VoiceEvent::NoteOn { key, velocity } = cv.event() else {
         panic!();
     };
@@ -126,7 +130,10 @@ fn note_off(reader: &mut Reader<&[u8]>, delta_ticks: u32, channel_id: u8, note: 
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), Channel::new(channel_id).unwrap());
+    assert_eq!(
+        cv.channel(),
+        Channel::try_from_primitive(channel_id).unwrap()
+    );
 
     match cv.event() {
         VoiceEvent::NoteOn { key, velocity } => {

--- a/midix/tests/simple_midi/main.rs
+++ b/midix/tests/simple_midi/main.rs
@@ -1,6 +1,53 @@
 use midix::prelude::*;
-use num_enum::TryFromPrimitive;
 mod parsed;
+
+/*
+4D546864            - "MThd"
+00000006            - chunk length: next 6 bytes
+00000001            - | 00 00: format 0 | 00 01: one track |
+0060                - 00 60: 96/qn
+4D54726B            - "MTrk"
+0000003B            - chunk length: next 59 bytes
+
+Note the following table:
+Midi Event            | DeltaT dec   |
+                      | w [Acc]      | Event and Details
+---------------------------------------------------------------------------------------------------
+00 FF5804 04021808  - | 00 [00]      | Meta Time Signature
+                      |              | (4 bytes; 4/4 time; 24 MIDI clocks/click
+                      |              | 8 32nd notes/24 MIDI clocks (24 MIDI clocks = 1 beat)
+                      |              |
+00 FF5103 07A120    - |  00 [00]     | Track Event Tempo
+                      |              | (3 bytes, 500_000 microsecs / quarter note = 120 beats/min)
+                      |              |
+00 C005             - |  00 [00]     | Ch1 Program Change to 5 (Electric Piano 2)
+                      |              |
+00 C12E             - |  00 [00]     | Ch2 Program Change to 46 (Harp)
+                      |              |
+00 C246             - |  00 [00]     | Ch3 Program Change to 71 (Bassoon)
+                      |              |
+00 923060           - |  00 [00]     | Ch3 Note on C3, Forte (96)
+                      |              |
+00 3C60             - |  00 [00]     | Note: Running Status
+                      |              | Ch3 Note on C4, Forte (96)
+                      |              |
+60 914340           - |  96 [96]     | Ch2 Note on G4, Mezzo-Forte (64)
+                      |              |
+60 904C20           - |  96 [192]    | Ch1 Note on E5, Piano (32)
+                      |              |
+8140 823040         - | 192 [384]    | Note: Two-byte Delta time
+                      |              | Ch3 Note off C3
+                      |              |
+00 3C40             - |  00 [384]    | Note: Running Status
+                      |              | Ch3 Note off
+                      |              |
+00 814340           - |  00 [384]    | Ch2 Note off G4
+                      |              |
+00 804C4            - |  00 [384]    | Ch1 Note off E5
+                      |              |
+00 0FF2F00          - |  00 [384]    | end of track
+*/
+
 #[test]
 fn midi_file_ref() {
     let bytes = include_bytes!("./simple.mid");
@@ -85,20 +132,21 @@ fn midi_file_ref() {
     assert_eq!(program.byte().value(), 70);
     /*************/
 
-    note_on(&mut reader, 0, 3, Note::C, 3, Dynamic::ff());
-    note_on(&mut reader, 0, 3, Note::C, 4, Dynamic::ff());
-    note_on(&mut reader, 96, 2, Note::G, 4, Dynamic::mf());
-    note_on(&mut reader, 96, 1, Note::E, 5, Dynamic::p());
-    note_off(&mut reader, 192, 3, Note::C, 3);
-    note_off(&mut reader, 0, 3, Note::C, 4);
-    note_off(&mut reader, 0, 2, Note::G, 4);
-    note_off(&mut reader, 0, 1, Note::E, 5);
+    use Channel::*;
+    note_on(&mut reader, 0, Three, Note::C, 3, Dynamic::ff());
+    note_on(&mut reader, 0, Three, Note::C, 4, Dynamic::ff());
+    note_on(&mut reader, 96, Two, Note::G, 4, Dynamic::mf());
+    note_on(&mut reader, 96, One, Note::E, 5, Dynamic::p());
+    note_off(&mut reader, 192, Three, Note::C, 3);
+    note_off(&mut reader, 0, Three, Note::C, 4);
+    note_off(&mut reader, 0, Two, Note::G, 4);
+    note_off(&mut reader, 0, One, Note::E, 5);
 }
 
 fn note_on(
     reader: &mut Reader<&[u8]>,
     delta_ticks: u32,
-    channel_id: u8,
+    channel: Channel,
     note: Note,
     octave: i8,
     dynamic: Dynamic,
@@ -110,10 +158,7 @@ fn note_on(
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(
-        cv.channel(),
-        Channel::try_from_primitive(channel_id).unwrap()
-    );
+    assert_eq!(cv.channel(), channel);
     let VoiceEvent::NoteOn { key, velocity } = cv.event() else {
         panic!();
     };
@@ -122,7 +167,13 @@ fn note_on(
     assert_eq!(velocity.dynamic(), dynamic);
 }
 
-fn note_off(reader: &mut Reader<&[u8]>, delta_ticks: u32, channel_id: u8, note: Note, octave: i8) {
+fn note_off(
+    reader: &mut Reader<&[u8]>,
+    delta_ticks: u32,
+    channel: Channel,
+    note: Note,
+    octave: i8,
+) {
     let Ok(FileEvent::TrackEvent(track_event)) = reader.read_event() else {
         panic!()
     };
@@ -130,10 +181,7 @@ fn note_off(reader: &mut Reader<&[u8]>, delta_ticks: u32, channel_id: u8, note: 
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(
-        cv.channel(),
-        Channel::try_from_primitive(channel_id).unwrap()
-    );
+    assert_eq!(cv.channel(), channel);
 
     match cv.event() {
         VoiceEvent::NoteOn { key, velocity } => {

--- a/midix/tests/simple_midi/main.rs
+++ b/midix/tests/simple_midi/main.rs
@@ -47,7 +47,7 @@ fn midi_file_ref() {
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), ChannelId::new(1).unwrap());
+    assert_eq!(cv.channel(), Channel::new(1).unwrap());
     let VoiceEvent::ProgramChange { program } = cv.event() else {
         panic!();
     };
@@ -62,7 +62,7 @@ fn midi_file_ref() {
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), ChannelId::new(2).unwrap());
+    assert_eq!(cv.channel(), Channel::new(2).unwrap());
     let VoiceEvent::ProgramChange { program } = cv.event() else {
         panic!();
     };
@@ -77,7 +77,7 @@ fn midi_file_ref() {
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), ChannelId::new(3).unwrap());
+    assert_eq!(cv.channel(), Channel::new(3).unwrap());
     let VoiceEvent::ProgramChange { program } = cv.event() else {
         panic!();
     };
@@ -109,7 +109,7 @@ fn note_on(
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), ChannelId::new(channel_id).unwrap());
+    assert_eq!(cv.channel(), Channel::new(channel_id).unwrap());
     let VoiceEvent::NoteOn { key, velocity } = cv.event() else {
         panic!();
     };
@@ -126,7 +126,7 @@ fn note_off(reader: &mut Reader<&[u8]>, delta_ticks: u32, channel_id: u8, note: 
     let TrackMessage::ChannelVoice(cv) = track_event.event() else {
         panic!();
     };
-    assert_eq!(cv.channel(), ChannelId::new(channel_id).unwrap());
+    assert_eq!(cv.channel(), Channel::new(channel_id).unwrap());
 
     match cv.event() {
         VoiceEvent::NoteOn { key, velocity } => {

--- a/midix/tests/simple_midi/parsed.rs
+++ b/midix/tests/simple_midi/parsed.rs
@@ -1,7 +1,7 @@
 use midix::{
     events::LiveEvent,
     file::{MidiFile, TimedEvent},
-    prelude::{ChannelId, VoiceEvent},
+    prelude::{Channel, VoiceEvent},
     DataByte, Dynamic, Note, Octave,
 };
 
@@ -37,7 +37,7 @@ fn note_on(
         panic!();
     };
 
-    assert_eq!(cv.channel(), ChannelId::new(channel_id).unwrap());
+    assert_eq!(cv.channel(), Channel::new(channel_id).unwrap());
     let VoiceEvent::NoteOn { key, velocity } = cv.event() else {
         panic!();
     };
@@ -58,7 +58,7 @@ fn note_off(
         panic!();
     };
 
-    assert_eq!(cv.channel(), ChannelId::new(channel_id).unwrap());
+    assert_eq!(cv.channel(), Channel::new(channel_id).unwrap());
     match cv.event() {
         VoiceEvent::NoteOn { key, velocity } => {
             assert_eq!(velocity.byte(), DataByte::new_unchecked(0));

--- a/midix/tests/simple_midi/parsed.rs
+++ b/midix/tests/simple_midi/parsed.rs
@@ -4,6 +4,7 @@ use midix::{
     prelude::{Channel, VoiceEvent},
     DataByte, Dynamic, Note, Octave,
 };
+use num_enum::TryFromPrimitive;
 
 #[test]
 fn test_parse() {
@@ -37,7 +38,10 @@ fn note_on(
         panic!();
     };
 
-    assert_eq!(cv.channel(), Channel::new(channel_id).unwrap());
+    assert_eq!(
+        cv.channel(),
+        Channel::try_from_primitive(channel_id).unwrap()
+    );
     let VoiceEvent::NoteOn { key, velocity } = cv.event() else {
         panic!();
     };
@@ -58,7 +62,10 @@ fn note_off(
         panic!();
     };
 
-    assert_eq!(cv.channel(), Channel::new(channel_id).unwrap());
+    assert_eq!(
+        cv.channel(),
+        Channel::try_from_primitive(channel_id).unwrap()
+    );
     match cv.event() {
         VoiceEvent::NoteOn { key, velocity } => {
             assert_eq!(velocity.byte(), DataByte::new_unchecked(0));

--- a/midix/tests/simple_midi/parsed.rs
+++ b/midix/tests/simple_midi/parsed.rs
@@ -4,7 +4,6 @@ use midix::{
     prelude::{Channel, VoiceEvent},
     DataByte, Dynamic, Note, Octave,
 };
-use num_enum::TryFromPrimitive;
 
 #[test]
 fn test_parse() {
@@ -16,19 +15,20 @@ fn test_parse() {
 
     let mut events = track.events().iter().skip(3);
 
-    note_on(events.next().unwrap(), 0, 3, Note::C, 3, Dynamic::ff());
-    note_on(events.next().unwrap(), 0, 3, Note::C, 4, Dynamic::ff());
-    note_on(events.next().unwrap(), 96, 2, Note::G, 4, Dynamic::mf());
-    note_on(events.next().unwrap(), 192, 1, Note::E, 5, Dynamic::p());
-    note_off(events.next().unwrap(), 384, 3, Note::C, 3);
-    note_off(events.next().unwrap(), 384, 3, Note::C, 4);
-    note_off(events.next().unwrap(), 384, 2, Note::G, 4);
-    note_off(events.next().unwrap(), 384, 1, Note::E, 5);
+    use Channel::*;
+    note_on(events.next().unwrap(), 0, Three, Note::C, 3, Dynamic::ff());
+    note_on(events.next().unwrap(), 0, Three, Note::C, 4, Dynamic::ff());
+    note_on(events.next().unwrap(), 96, Two, Note::G, 4, Dynamic::mf());
+    note_on(events.next().unwrap(), 192, One, Note::E, 5, Dynamic::p());
+    note_off(events.next().unwrap(), 384, Three, Note::C, 3);
+    note_off(events.next().unwrap(), 384, Three, Note::C, 4);
+    note_off(events.next().unwrap(), 384, Two, Note::G, 4);
+    note_off(events.next().unwrap(), 384, One, Note::E, 5);
 }
 fn note_on(
     e: &TimedEvent<LiveEvent<'_>>,
     accumulated_ticks: u32,
-    channel_id: u8,
+    channel: Channel,
     note: Note,
     octave: i8,
     dynamic: Dynamic,
@@ -38,10 +38,7 @@ fn note_on(
         panic!();
     };
 
-    assert_eq!(
-        cv.channel(),
-        Channel::try_from_primitive(channel_id).unwrap()
-    );
+    assert_eq!(cv.channel(), channel);
     let VoiceEvent::NoteOn { key, velocity } = cv.event() else {
         panic!();
     };
@@ -53,7 +50,7 @@ fn note_on(
 fn note_off(
     e: &TimedEvent<LiveEvent<'_>>,
     accumulated_ticks: u32,
-    channel_id: u8,
+    channel: Channel,
     note: Note,
     octave: i8,
 ) {
@@ -62,10 +59,7 @@ fn note_off(
         panic!();
     };
 
-    assert_eq!(
-        cv.channel(),
-        Channel::try_from_primitive(channel_id).unwrap()
-    );
+    assert_eq!(cv.channel(), channel);
     match cv.event() {
         VoiceEvent::NoteOn { key, velocity } => {
             assert_eq!(velocity.byte(), DataByte::new_unchecked(0));


### PR DESCRIPTION
To strongly type Channels, `ChannelId` has become `Channel` with Sixteen variants.

Additionally, `Channel` uses `TryFromPrimitive` and `IntoPrimitive`.

Should close #16 