### PR TITLE
Update CHANGELOG.md for v3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,84 @@
 Welcome to v3. `midix` introduces significant updates and improvements for MIDI handling and integration!
 
 ## Notes
-This release includes major refactoring, new features, and breaking changes. It focuses on enhancing MIDI file reading, removing unnecessary `Cow<'_, u8>` usage, and improving the `bevy_midix` examples. Please report any issues encountered.
+This release includes major refactoring, new features, and breaking changes. It focuses on enhancing MIDI file reading, removing unnecessary `Cow<'_, u8>` usage, and a complete refactor of `bevy_midix`. Please report any issues encountered.
 
-## Features
-- Added a new piano and input example for `bevy_midix`.
-- Introduced the ability to insert an SF2 resource and customize synthesizer parameters.
+## `bevy_midix`
+### Features
+- Added a new piano and input example.
+  - In the future, I will add the usage of a MIDI file.
+- Introduced the ability to insert an SF2 resource and customize synthesizer parameters (sample rate).
+
+See examples for details.
+
 - Enhanced `midix_synth` with better soundfont handling and synthesizer improvements.
-- Improved documentation across all crates.
 - Added support for additional MIDI formats in `midix` file parsing.
 
-## Breaking Changes
-- Refactored `MidiOutputPlugin` and `MidiInput` APIs to streamline connection handling.
+### Breaking Changes
+- Refactored `MidiOutput` and `MidiInput` APIs to streamline connection handling.
+
+Note, especially for linux users:
+
+I have unsafely implemented `Sync` for these resources. I have **"assumed"** that users will NOT have a second
+`midir::MidiInput` or `midir::MidiOutput` instance in their programs. I have not run into issues testing on my
+own linux device, but this implementation *MAY* be frivolous. If you find `UB`, please let me know ASAP so I can
+work on finding an alternative. I expect UB to represent itself as these plugins not listening nor active,
+so errors should only be confined to safely handled interfaces.
+
+- for `MidiOutput`, you may send only types that implement `Into<MidiMessageBytes>`.
+
+Implementors of this type should be all `LiveEvent`s, but there may be others that
+will be included in futures minor releases.
+
+
+
+### Chores
+- Updated to Bevy `0.16.0-rc4`.
+  - Will update to `0.16` for `v3.1.0`.
+
+## `midix`
+
+### Features
+- `.mid` file reading is now possible! see `/midix/tests/read_all.rs` for a reference.
+
+### Breaking Changes
 - Removed `Cow<'_, u8>` usage in many areas for better performance and simplicity.
+It is faster to copy a `u8` than it is to reference the `u8`. Starting with this was more
+of an experiment than a decent way to be "min-copy". As a result, there is an opportunity now
+to create a parsing Struct that references an underlying byte slice, like that of [ttf-parser's Face](https://docs.rs/ttf-parser/0.25.1/ttf_parser/struct.Face.html).
+
 - Updated `ChannelId` to a `Channel` enum.
+The `Channel` enum is now an enumeration of "One" to "Sixteen".
+
+### Notes
+
+- Reading/Writing to byte slices
+Some of the APIs need work, particularly for reading to and writing to byte slices.
+
+I will be cleaning this up for v4, and will begin deprecating poor interfaces throughout
+v3 minor releases.
+
+This work will include progress to writing out to midi slices
+
+- ControlChange
+
+Currently, there are things like pedals, external devices
+that deserve an enumeration rather than a raw byte value. I will be working
+on this conversion throughout v3, and hopefully as the default type for v4.
+
+
+
 
 ## Chores
-- Upgraded to the 2024 edition of Rust.
-- Updated to Bevy `0.16.0-rc4`.
-- Cleaned up lints and documentation.
+- Upgraded all crates to the 2024 edition of Rust.
+- Improved documentation across all crates.
 - Updated dependencies to their latest versions.
 - Improved test coverage for `midix` and `bevy_midix`.
+
+## Final Notes
+There are some methods that now return other types.
+If I have missed something important in these release notes,
+do not hesistate to file an issue explaining your frustrations.
 
 **Full Changelog**: https://github.com/dsgallups/midix/compare/2.0.0...3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 3.0.0 (April 13, 2025)
+Welcome to v3. `midix` introduces significant updates and improvements for MIDI handling and integration!
+
+## Notes
+This release includes major refactoring, new features, and breaking changes. It focuses on enhancing MIDI file reading, removing unnecessary `Cow<'_, u8>` usage, and improving the `bevy_midix` examples. Please report any issues encountered.
+
+## Features
+- Added a new piano and input example for `bevy_midix`.
+- Introduced the ability to insert an SF2 resource and customize synthesizer parameters.
+- Enhanced `midix_synth` with better soundfont handling and synthesizer improvements.
+- Improved documentation across all crates.
+- Added support for additional MIDI formats in `midix` file parsing.
+
+## Breaking Changes
+- Refactored `MidiOutputPlugin` and `MidiInput` APIs to streamline connection handling.
+- Removed `Cow<'_, u8>` usage in many areas for better performance and simplicity.
+- Updated `ChannelId` to a `Channel` enum.
+
+## Chores
+- Upgraded to the 2024 edition of Rust.
+- Updated to Bevy `0.16.0-rc4`.
+- Cleaned up lints and documentation.
+- Updated dependencies to their latest versions.
+- Improved test coverage for `midix` and `bevy_midix`.
+
+**Full Changelog**: https://github.com/dsgallups/midix/compare/2.0.0...3.0.0
+
 # 2.0.0 (December 30, 2024)
 Welcome to v2. `midix` has new types that will be used for future MIDI representations and methods!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ See examples for details.
 
 Note, especially for linux users:
 
-I have unsafely implemented `Sync` for these resources. I have **"assumed"** that users will NOT have a second
+I have unsafely implemented `Sync` for these resources. This is because `midir` uses `alsa` for midi IO under the hood for this target. I have **assumed** that users will NOT have a second
 `midir::MidiInput` or `midir::MidiOutput` instance in their programs. I have not run into issues testing on my
 own linux device, but this implementation *MAY* be frivolous. If you find `UB`, please let me know ASAP so I can
 work on finding an alternative. I expect UB to represent itself as these plugins not listening nor active,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,6 @@ dependencies = [
  "midir",
  "midix",
  "midix_synth",
- "strum 0.27.1",
  "thiserror 2.0.12",
  "tinyaudio",
 ]
@@ -2772,7 +2771,7 @@ dependencies = [
  "pp-rs",
  "rustc-hash",
  "spirv",
- "strum 0.26.3",
+ "strum",
  "termcolor",
  "thiserror 2.0.12",
  "unicode-xid",
@@ -3853,16 +3852,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
-dependencies = [
- "strum_macros 0.27.1",
+ "strum_macros",
 ]
 
 [[package]]
@@ -3870,19 +3860,6 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # midix
+[<img alt="github" src="https://img.shields.io/badge/github-dsgallups/color-gen?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/dsgallups/midix)
 
 A suite of tools used to read, modify, and manage MIDI-related systems
 
 # Crates
 
-- `midix` - MIDI live/file parsing
+- `midix` - MIDI live/file parsing/type for programmable MIDI
+[<img alt="crates.io" src="https://img.shields.io/crates/v/midix.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/midix)
+
+
+
 - `bevy_midix` - MIDI event resource and handlers
+[<img alt="crates.io" src="https://img.shields.io/crates/v/bevy_midix.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/bevy_midix)
+
 - `midix_synth` - Streaming midi-command SoundFont synth (Under heavy development)
 
 ## MIDIx feature roadmap

--- a/README.md
+++ b/README.md
@@ -5,15 +5,20 @@ A suite of tools used to read, modify, and manage MIDI-related systems
 
 # Crates
 
-- `midix` - MIDI live/file parsing/type for programmable MIDI
+- `midix`
+
 [<img alt="crates.io" src="https://img.shields.io/crates/v/midix.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/midix)
 
+MIDI live/file parsing/type for programmable MIDI
 
 
-- `bevy_midix` - MIDI event resource and handlers
+- `bevy_midix`
+
 [<img alt="crates.io" src="https://img.shields.io/crates/v/bevy_midix.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/bevy_midix)
+- MIDI event resource and handlers
 
 - `midix_synth` - Streaming midi-command SoundFont synth (Under heavy development)
+
 
 ## MIDIx feature roadmap
 - `no_std`

--- a/bevy_midix/Cargo.toml
+++ b/bevy_midix/Cargo.toml
@@ -22,9 +22,6 @@ thiserror = "2.0"
 tinyaudio = "1.1.0"
 itertools = "0.14.0"
 
-[dev-dependencies]
-strum = { version = "0.27", features = ["derive"] }
-
 [dependencies.bevy]
 version = "0.16.0-rc.4"
 default-features = false

--- a/bevy_midix/README.md
+++ b/bevy_midix/README.md
@@ -1,6 +1,6 @@
 # bevy_MIDIx
 Bevy plugin that uses [`midix`](https://crates.io/crates/midix),
-[`midir`](https://github.com/Boddlnagg/midir).
+[`midir`](https://github.com/Boddlnagg/midir), and a [`rustysynth`](https://github.com/sinshu/rustysynth) fork to play midi sounds!
 
 Read from MIDI devices, MIDI files, and programmable input, and output to user audio with a soundfont!
 
@@ -85,6 +85,7 @@ impl Default for Scale {
 }
 
 fn scale_me(synth: Res<Synth>, time: Res<Time>, mut scale: Local<Scale>) {
+    // don't do anything until the soundfont has been loaded
     if !synth.is_ready() {
         return;
     }

--- a/bevy_midix/README.md
+++ b/bevy_midix/README.md
@@ -1,4 +1,7 @@
 # bevy_MIDIx
+[<img alt="github" src="https://img.shields.io/badge/github-dsgallups/color-gen?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/dsgallups/midix)
+[<img alt="crates.io" src="https://img.shields.io/crates/v/bevy_midix.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/bevy_midix)
+
 Bevy plugin that uses [`midix`](https://crates.io/crates/midix),
 [`midir`](https://github.com/Boddlnagg/midir), and a [`rustysynth`](https://github.com/sinshu/rustysynth) fork to play midi sounds!
 

--- a/bevy_midix/examples/scale.rs
+++ b/bevy_midix/examples/scale.rs
@@ -1,12 +1,5 @@
-# bevy_MIDIx
-Bevy plugin that uses [`midix`](https://crates.io/crates/midix),
-[`midir`](https://github.com/Boddlnagg/midir).
-
-Read from MIDI devices, MIDI files, and programmable input, and output to user audio with a soundfont!
-
-# Example
-```rust, no_run
 use std::time::Duration;
+
 use bevy::{
     log::{Level, LogPlugin},
     prelude::*,
@@ -93,13 +86,14 @@ fn scale_me(synth: Res<Synth>, time: Res<Time>, mut scale: Local<Scale>) {
         return;
     }
     if scale.note_on {
+        info!("Note on {}!", scale.current_key);
         //play note on
         synth.handle_event(ChannelVoiceMessage::new(
             Channel::One,
             VoiceEvent::note_on(scale.current_key, Velocity::max()),
         ));
     } else {
-        //turn off the note
+        info!("Note off {}!", scale.current_key);
         synth.handle_event(ChannelVoiceMessage::new(
             Channel::One,
             VoiceEvent::note_off(scale.current_key, Velocity::max()),
@@ -109,11 +103,3 @@ fn scale_me(synth: Res<Synth>, time: Res<Time>, mut scale: Local<Scale>) {
 
     scale.note_on = !scale.note_on;
 }
-```
-
-See `/examples` for details.
-
-
-# Acknowledgment
-
-This crate was originally forked from [`bevy_midi`](https://github.com/BlackPhlox/bevy_midi). Please check them out if this crate doesn't suit your needs!

--- a/bevy_midix/src/asset/sound_font.rs
+++ b/bevy_midix/src/asset/sound_font.rs
@@ -26,10 +26,6 @@ impl SoundFont {
 
         Ok(Self { file: sf })
     }
-    // /// Provides the interior font
-    // pub fn font(&self) -> &Arc<Sf> {
-    //     &self.file
-    // }
 }
 
 /// Possible errors that can be produced by [`CustomAssetLoader`]

--- a/bevy_midix/src/plugin.rs
+++ b/bevy_midix/src/plugin.rs
@@ -45,15 +45,3 @@ impl Plugin for MidiPlugin {
         }
     }
 }
-/*
-
-We should have it such that
-user can load sf2 file in asset server
-
-user can, on startup, get a handle to that.
-
-Then say
-synth.use_soundfont(handle: Handle<SoundFont>);
-
-
-*/

--- a/midix/README.md
+++ b/midix/README.md
@@ -1,15 +1,19 @@
-
-Composable, parsable MIDI structures
+Human readable MIDI structures
 
 
 
 # Overview
 
-`midix` provides a min-copy parser ([`Reader`](crate::prelude::Reader)) to read events from `.mid` files.
+`midix` provides a parser ([`Reader`](crate::prelude::Reader)) to read events from `.mid` files.
 calling [`Reader::read_event`](crate::prelude::Reader::read_event) will yield a [`FileEvent`](crate::prelude::FileEvent).
 
-Additionally, `midix` provides the user with [`LiveEvent::from_bytes`](crate::events::LiveEvent), which will parse
-events from a live MIDI source.
+Additionally, `midix` provides the user with [`LiveEvent::from_bytes`](crate::events::LiveEvent), which will parse events from a live MIDI source.
+
+You may also make your own MIDI representation using the provided structs. If check out
+[`bevy_midix`](https://github.com/dsgallups/midix/bevy_midix) if you'd like to use `midix` in your games!
+
+## Goal
+`midix` is NOT designed to be as fast as possible. It is designed for a user to navigate the MIDI format to read and write to. Instead of working directly with bytes, use language to define what your MIDI is supposed to do.
 
 # Getting Started
 

--- a/midix/README.md
+++ b/midix/README.md
@@ -1,3 +1,6 @@
+# MIDIx
+[<img alt="github" src="https://img.shields.io/badge/github-dsgallups/color-gen?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/dsgallups/midix)
+[<img alt="crates.io" src="https://img.shields.io/crates/v/midix.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/midix)
 Human readable MIDI structures
 
 

--- a/midix/src/file_repr/meta/time_signature.rs
+++ b/midix/src/file_repr/meta/time_signature.rs
@@ -37,7 +37,7 @@ impl Default for TimeSignature<'_> {
 }
 
 impl<'a> TimeSignature<'a> {
-    /// 4 bytes; 4/4 time; 24 MIDI clocks/click, 8 32nd notes/ 24 MIDI clocks (24 MIDI clocks = 1 crotchet = 1 beat)
+    /// 4 bytes; 6/8 time; 24 MIDI clocks/click, 8 32nd notes/ 24 MIDI clocks (24 MIDI clocks = 1 crotchet = 1 beat)
     /// is represented by
     /// ```rust
     /// # use midix::prelude::*;

--- a/midix_synth/README.md
+++ b/midix_synth/README.md
@@ -11,4 +11,4 @@ DIRECTLY from [rustysynth v1.3.3](https://github.com/sinshu/rustysynth).
 
 This crate refactors portions of `rustysynth` to operate cohesively with `bevy_midix`.
 
-It should not be used *independently*. Thanks!!
+It should not be used *independently* just yet.

--- a/midix_synth/README.md
+++ b/midix_synth/README.md
@@ -9,4 +9,6 @@ Most of this code, and the
 respective challenges of implementation comes
 DIRECTLY from [rustysynth v1.3.3](https://github.com/sinshu/rustysynth).
 
-This crate refactors portions of `rustysynth` to operate cohesively with `midix`.
+This crate refactors portions of `rustysynth` to operate cohesively with `bevy_midix`.
+
+It should not be used *independently*. Thanks!!


### PR DESCRIPTION
- Updated `README`s and `CHANGELOG`
- Implemented `Add`, `Sub`, `AddAssign`, and `SubAssign` for `Key` where `Rhs = u8`
- Added `scale` example for bevy