### PR TITLE
fix: use web_time for wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,7 @@ dependencies = [
  "rustysynth",
  "thiserror 2.0.12",
  "tinyaudio",
+ "web-time",
 ]
 
 [[package]]

--- a/bevy_midix/Cargo.toml
+++ b/bevy_midix/Cargo.toml
@@ -40,6 +40,9 @@ features = [
     "std",
 ]
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = "1.1.0"
+
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 

--- a/bevy_midix/examples/iterate_voices.rs
+++ b/bevy_midix/examples/iterate_voices.rs
@@ -1,4 +1,7 @@
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
+#[cfg(target_arch = "wasm32")]
+use web_time::Duration;
 
 use bevy::{
     log::{Level, LogPlugin},

--- a/bevy_midix/examples/pitchbend.rs
+++ b/bevy_midix/examples/pitchbend.rs
@@ -1,4 +1,7 @@
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
+#[cfg(target_arch = "wasm32")]
+use web_time::Duration;
 
 use bevy::{
     log::{Level, LogPlugin},

--- a/bevy_midix/examples/programmatic_song.rs
+++ b/bevy_midix/examples/programmatic_song.rs
@@ -1,4 +1,7 @@
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
+#[cfg(target_arch = "wasm32")]
+use web_time::Duration;
 
 use bevy::{
     log::{Level, LogPlugin},

--- a/bevy_midix/examples/scale.rs
+++ b/bevy_midix/examples/scale.rs
@@ -1,4 +1,7 @@
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
+#[cfg(target_arch = "wasm32")]
+use web_time::Duration;
 
 use bevy::{
     log::{Level, LogPlugin},

--- a/bevy_midix/src/synth/sink/task.rs
+++ b/bevy_midix/src/synth/sink/task.rs
@@ -1,9 +1,12 @@
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::{Duration, Instant};
 use std::{
     collections::VecDeque,
     pin::Pin,
     task::{Context, Poll},
-    time::{Duration, Instant},
 };
+#[cfg(target_arch = "wasm32")]
+use web_time::{Duration, Instant};
 
 use bevy::log::info;
 /*


### PR DESCRIPTION
std::time::Duration/Instant is not supported on web.

For these reasons, we can use `web_time` as a drop-in replacement.