### PR TITLE
Synthesizer method renaming + new methods, update SynthConfig params (ev reading)

### DIFF
--- a/bevy_midix/README.md
+++ b/bevy_midix/README.md
@@ -97,13 +97,13 @@ fn scale_me(synth: Res<Synth>, time: Res<Time>, mut scale: Local<Scale>) {
     }
     if scale.note_on {
         //play note on
-        _ = synth.handle_event(ChannelVoiceMessage::new(
+        _ = synth.push_event(ChannelVoiceMessage::new(
             Channel::One,
             VoiceEvent::note_on(scale.current_key, Velocity::MAX),
         ));
     } else {
         //turn off the note
-        _ = synth.handle_event(ChannelVoiceMessage::new(
+        _ = synth.push_event(ChannelVoiceMessage::new(
             Channel::One,
             VoiceEvent::note_off(scale.current_key, Velocity::MAX),
         ));

--- a/bevy_midix/examples/2dpiano.rs
+++ b/bevy_midix/examples/2dpiano.rs
@@ -144,7 +144,7 @@ fn handle_input(
                     *background_color = PRESSED.into();
                     let event =
                         VoiceEvent::note_on(*key, Velocity::MAX).send_to_channel(Channel::One);
-                    _ = synth.handle_event(event);
+                    _ = synth.push_event(event);
                 } else {
                     *background_color = HOVERED.into();
                 }
@@ -168,7 +168,7 @@ fn on_mouse_up(
     let event = VoiceEvent::note_on(*key, Velocity::ZERO).send_to_channel(Channel::One);
     // could make this beter and revert to hover, but lazy
     *background_color = HOVERED.into();
-    _ = synth.handle_event(event);
+    _ = synth.push_event(event);
 }
 
 // because Interaction::Pressed doesn't do anything if you leave pressed.
@@ -180,5 +180,5 @@ fn on_mouse_leave(
     let (mut background_color, key) = keys.get_mut(trigger.target()).unwrap();
     *background_color = BackgroundColor(bg_color(key.is_sharp()));
     let event = VoiceEvent::note_on(*key, Velocity::ZERO).send_to_channel(Channel::One);
-    _ = synth.handle_event(event);
+    _ = synth.push_event(event);
 }

--- a/bevy_midix/examples/input/main.rs
+++ b/bevy_midix/examples/input/main.rs
@@ -47,6 +47,6 @@ fn handle_mididata(midi_input: Res<MidiInput>, synth: Res<Synth>) {
         };
 
         info!("Data: {:?}", data.message);
-        _ = synth.handle_event(event);
+        _ = synth.push_event(event);
     }
 }

--- a/bevy_midix/examples/input_2dpiano/main.rs
+++ b/bevy_midix/examples/input_2dpiano/main.rs
@@ -58,7 +58,7 @@ fn handle_mididata(
 
         info!("Data: {:?}", data.message);
         //todo
-        _ = synth.handle_event(event);
+        _ = synth.push_event(event);
         ev.write(ExampleInputEvent {
             voice: *event.event(),
         });

--- a/bevy_midix/examples/input_2dpiano/ui/piano.rs
+++ b/bevy_midix/examples/input_2dpiano/ui/piano.rs
@@ -160,7 +160,7 @@ pub fn handle_input(
                     *background_color = PRESSED.into();
                     let event =
                         VoiceEvent::note_on(*key, Velocity::MAX).send_to_channel(Channel::One);
-                    _ = synth.handle_event(event);
+                    _ = synth.push_event(event);
                 } else {
                     *background_color = HOVERED.into();
                 }
@@ -260,7 +260,7 @@ fn on_mouse_up(
     let event = VoiceEvent::note_on(*key, Velocity::ZERO).send_to_channel(Channel::One);
     // could make this beter and revert to hover, but lazy
     *background_color = HOVERED.into();
-    _ = synth.handle_event(event);
+    _ = synth.push_event(event);
 }
 
 // because Interaction::Pressed doesn't do anything if you leave pressed.
@@ -272,5 +272,5 @@ fn on_mouse_leave(
     let (mut background_color, key) = keys.get_mut(trigger.target()).unwrap();
     *background_color = BackgroundColor(bg_color(key.is_sharp()));
     let event = VoiceEvent::note_on(*key, Velocity::ZERO).send_to_channel(Channel::One);
-    _ = synth.handle_event(event);
+    _ = synth.push_event(event);
 }

--- a/bevy_midix/examples/iterate_voices.rs
+++ b/bevy_midix/examples/iterate_voices.rs
@@ -64,7 +64,7 @@ fn iterate_voices(synth: Res<Synth>, time: Res<Time>, mut scale: Local<VoiceChan
     ];
     info!("Voice {}!", scale.voice_number);
     for key in C_CHORD {
-        _ = synth.handle_event(ChannelVoiceMessage::new(
+        _ = synth.push_event(ChannelVoiceMessage::new(
             Channel::One,
             VoiceEvent::note_off(key, Velocity::MAX),
         ));
@@ -74,13 +74,13 @@ fn iterate_voices(synth: Res<Synth>, time: Res<Time>, mut scale: Local<VoiceChan
     } else {
         scale.voice_number += 1;
     }
-    _ = synth.handle_event(ChannelVoiceMessage::new(
+    _ = synth.push_event(ChannelVoiceMessage::new(
         Channel::One,
         // unwrapping is okay, because we don't go past 127.
         VoiceEvent::program_change(Program::new(scale.voice_number).unwrap()),
     ));
     for key in C_CHORD {
-        _ = synth.handle_event(ChannelVoiceMessage::new(
+        _ = synth.push_event(ChannelVoiceMessage::new(
             Channel::One,
             VoiceEvent::note_on(key, Velocity::MAX),
         ));

--- a/bevy_midix/examples/pitchbend.rs
+++ b/bevy_midix/examples/pitchbend.rs
@@ -68,7 +68,7 @@ fn iterate_voices(synth: Res<Synth>, time: Res<Time>, mut scale: Local<VoiceChan
         message.data_1_byte(),
         message.data_2_byte().unwrap()
     );
-    _ = synth.handle_event(ChannelVoiceMessage::new(
+    _ = synth.push_event(ChannelVoiceMessage::new(
         Channel::One,
         VoiceEvent::PitchBend(PitchBend::new(0, msb).unwrap()),
     ));
@@ -79,7 +79,7 @@ fn iterate_voices(synth: Res<Synth>, time: Res<Time>, mut scale: Local<VoiceChan
     const BASE_OCTAVE: i8 = 4;
     let key = Key::new(Note::C, Octave::new(BASE_OCTAVE));
 
-    _ = synth.handle_event(ChannelVoiceMessage::new(
+    _ = synth.push_event(ChannelVoiceMessage::new(
         Channel::One,
         VoiceEvent::note_on(key, Velocity::MAX),
     ));

--- a/bevy_midix/examples/play_file.rs
+++ b/bevy_midix/examples/play_file.rs
@@ -35,7 +35,7 @@ fn load_sf2(mut commands: Commands, asset_server: Res<AssetServer>, mut synth: R
 }
 
 fn play_song(
-    synth: Res<Synth>,
+    mut synth: ResMut<Synth>,
     file: Res<LoadedFile>,
     assets: Res<Assets<MidiFile>>,
     mut run: Local<bool>,

--- a/bevy_midix/examples/programmatic_simple_song.rs
+++ b/bevy_midix/examples/programmatic_simple_song.rs
@@ -44,7 +44,11 @@ impl Default for PlaySongAgain {
         Self { timer, count: 0 }
     }
 }
-fn make_song(synth: Res<Synth>, mut play_again: Local<Option<PlaySongAgain>>, timer: Res<Time>) {
+fn make_song(
+    mut synth: ResMut<Synth>,
+    mut play_again: Local<Option<PlaySongAgain>>,
+    timer: Res<Time>,
+) {
     if !synth.is_ready() {
         return;
     }

--- a/bevy_midix/examples/scale.rs
+++ b/bevy_midix/examples/scale.rs
@@ -88,13 +88,13 @@ fn scale_me(synth: Res<Synth>, time: Res<Time>, mut scale: Local<Scale>) {
     if scale.note_on {
         info!("Note on {}!", scale.current_key);
         //play note on
-        _ = synth.handle_event(ChannelVoiceMessage::new(
+        _ = synth.push_event(ChannelVoiceMessage::new(
             Channel::One,
             VoiceEvent::note_on(scale.current_key, Velocity::MAX),
         ));
     } else {
         info!("Note off {}!", scale.current_key);
-        _ = synth.handle_event(ChannelVoiceMessage::new(
+        _ = synth.push_event(ChannelVoiceMessage::new(
             Channel::One,
             VoiceEvent::note_off(scale.current_key, Velocity::MAX),
         ));

--- a/bevy_midix/src/asset/midi_file.rs
+++ b/bevy_midix/src/asset/midi_file.rs
@@ -21,6 +21,8 @@ use midix::{
 use crate::song::MidiSong;
 
 /// Sound font asset. Wraps a midix MidiFile
+///
+/// TODO(before v4: do not wrap midix MidiFile)
 #[derive(Asset, TypePath)]
 pub struct MidiFile {
     inner: Mf<'static>,

--- a/bevy_midix/src/song/mod.rs
+++ b/bevy_midix/src/song/mod.rs
@@ -53,7 +53,7 @@ impl MidiSong {
     pub fn events_mut(&mut self) -> &mut Vec<Timed<ChannelVoiceMessage>> {
         &mut self.events
     }
-
+    /// Start the song paused
     pub fn set_paused(mut self) -> Self {
         self.paused = true;
         self

--- a/bevy_midix/src/song/mod.rs
+++ b/bevy_midix/src/song/mod.rs
@@ -36,6 +36,14 @@ pub struct MidiSong {
 }
 
 impl MidiSong {
+    /// Get the ID for this song.
+    ///
+    /// While MidiSong implements [`SongWriter`],
+    /// the value of ID is never optional in this case.
+    #[inline]
+    pub fn id(&self) -> SongId {
+        self.id
+    }
     /// Returns a builder to build a midi song
     pub fn builder() -> MidiSongBuilder {
         MidiSongBuilder::default()

--- a/bevy_midix/src/song/mod.rs
+++ b/bevy_midix/src/song/mod.rs
@@ -31,6 +31,8 @@ pub struct MidiSong {
     pub(crate) events: Vec<Timed<ChannelVoiceMessage>>,
     /// If true, this will loop when sent to the synthesizer.
     pub looped: bool,
+    /// If true, then this song starts paused.
+    pub paused: bool,
 }
 
 impl MidiSong {
@@ -44,11 +46,17 @@ impl MidiSong {
             id: SongId::default(),
             events,
             looped: false,
+            paused: false,
         }
     }
     /// Get a mutable reference to the events
     pub fn events_mut(&mut self) -> &mut Vec<Timed<ChannelVoiceMessage>> {
         &mut self.events
+    }
+
+    pub fn set_paused(mut self) -> Self {
+        self.paused = true;
+        self
     }
 
     /// Commands should be looped
@@ -82,5 +90,8 @@ impl SongWriter for MidiSong {
     }
     fn looped(&self) -> bool {
         self.looped
+    }
+    fn paused(&self) -> bool {
+        self.paused
     }
 }

--- a/bevy_midix/src/song/song_writer.rs
+++ b/bevy_midix/src/song/song_writer.rs
@@ -20,6 +20,7 @@ pub trait SongWriter {
     fn looped(&self) -> bool {
         false
     }
+    /// Is this song paused, or does it play instantly?
     fn paused(&self) -> bool {
         false
     }

--- a/bevy_midix/src/song/song_writer.rs
+++ b/bevy_midix/src/song/song_writer.rs
@@ -1,6 +1,5 @@
-use std::iter;
+use std::{collections::HashMap, hash::BuildHasher, iter};
 
-use fnv::FnvHashMap;
 use midix::prelude::{Channel, ChannelVoiceMessage, Timed, VoiceEvent};
 
 use super::SongId;
@@ -24,9 +23,11 @@ pub trait SongWriter {
     fn paused(&self) -> bool {
         false
     }
-    /// Helper method that will divide events into individual channels
-    fn divide_events_into_channels(&self) -> FnvHashMap<Channel, Vec<Timed<VoiceEvent>>> {
-        let mut map: FnvHashMap<Channel, Vec<Timed<VoiceEvent>>> = FnvHashMap::default();
+    /// Helper method that will divide events into individual channels using a hasher of the caller's choice.
+    fn divide_events_into_channels<S: BuildHasher + Default>(
+        &self,
+    ) -> HashMap<Channel, Vec<Timed<VoiceEvent>>, S> {
+        let mut map: HashMap<Channel, Vec<Timed<VoiceEvent>>, S> = HashMap::default();
 
         for event in self.events() {
             let voice_events = map.entry(event.event.channel()).or_default();

--- a/bevy_midix/src/song/song_writer.rs
+++ b/bevy_midix/src/song/song_writer.rs
@@ -20,6 +20,9 @@ pub trait SongWriter {
     fn looped(&self) -> bool {
         false
     }
+    fn paused(&self) -> bool {
+        false
+    }
     /// Helper method that will divide events into individual channels
     fn divide_events_into_channels(&self) -> FnvHashMap<Channel, Vec<Timed<VoiceEvent>>> {
         let mut map: FnvHashMap<Channel, Vec<Timed<VoiceEvent>>> = FnvHashMap::default();

--- a/bevy_midix/src/synth/mod.rs
+++ b/bevy_midix/src/synth/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use bevy::prelude::*;
 use crossbeam_channel::{SendError, Sender};
 use midix::prelude::{ChannelVoiceMessage, Timed};
-use std::sync::Mutex;
+use std::{collections::HashMap, sync::Mutex};
 use thiserror::Error;
 use tinyaudio::OutputDevice;
 
@@ -61,6 +61,12 @@ impl From<SendError<ChannelVoiceMessage>> for SynthError {
     }
 }
 
+/// doesn't care if looped. the resource should not
+/// time this.
+struct StoredSong {
+    events: Vec<Timed<ChannelVoiceMessage>>,
+}
+
 /// Plays audio commands with the provided soundfont
 ///
 /// Pass the synth midi events via the `Synth::handle_event` method
@@ -70,6 +76,7 @@ impl From<SendError<ChannelVoiceMessage>> for SynthError {
 pub struct Synth {
     params: SynthParams,
     synthesizer: SynthState,
+    store: HashMap<SongId, StoredSong>,
     _device: Option<Mutex<OutputDevice>>,
 }
 
@@ -190,6 +197,7 @@ impl Default for Synth {
     fn default() -> Self {
         Self {
             params: SynthParams::default(),
+            store: HashMap::default(),
             synthesizer: SynthState::NotLoaded,
             _device: None,
         }

--- a/bevy_midix/src/synth/mod.rs
+++ b/bevy_midix/src/synth/mod.rs
@@ -77,7 +77,7 @@ impl Synth {
     /// # Errors
     ///
     /// If the synth is not ready for commands. See [`Synth::is_ready`]
-    pub fn handle_event(&self, event: ChannelVoiceMessage) -> Result<(), SynthError> {
+    pub fn push_event(&self, event: ChannelVoiceMessage) -> Result<(), SynthError> {
         let SynthState::Loaded { synth_channel, .. } = &self.synthesizer else {
             error!("An event was passed to the synth, but the soundfont has not been loaded!");
             return Err(SynthError::NotReady);

--- a/bevy_midix/src/synth/sink/commands.rs
+++ b/bevy_midix/src/synth/sink/commands.rs
@@ -2,37 +2,14 @@ use midix::prelude::*;
 
 use crate::song::SongId;
 
-/// The type of song that will be sent to the synth
-#[derive(Clone, Copy)]
-pub(crate) enum SongType {
-    /// No identifier, and therefore, no looping
-    Anonymous,
-    /// An identifier, and therefore, looping
-    Identified {
-        /// The song identifer
-        id: SongId,
-        /// true if it loops
-        looped: bool,
-    },
-}
-
-impl SongType {
-    pub(crate) fn id(&self) -> Option<SongId> {
-        match self {
-            SongType::Anonymous => None,
-            SongType::Identified { id, .. } => Some(*id),
-        }
-    }
-}
-
 /// Command the sink to do something
 pub(crate) enum SinkCommand {
     /// Play an event in time x
     PlayEvent(Timed<ChannelVoiceMessage>),
     /// Play a new song
     NewSong {
-        /// What kind of song is this?
-        song_type: SongType,
+        id: SongId,
+        looped: bool,
         /// The associated events with the song
         commands: Vec<Timed<ChannelVoiceMessage>>,
     },

--- a/bevy_midix/src/synth/sink/commands.rs
+++ b/bevy_midix/src/synth/sink/commands.rs
@@ -27,6 +27,8 @@ impl SongType {
 
 /// Command the sink to do something
 pub(crate) enum SinkCommand {
+    /// Play an event in time x
+    PlayEvent(Timed<ChannelVoiceMessage>),
     /// Play a new song
     NewSong {
         /// What kind of song is this?

--- a/bevy_midix/src/synth/sink/task.rs
+++ b/bevy_midix/src/synth/sink/task.rs
@@ -9,7 +9,7 @@ use std::{
 #[cfg(feature = "web")]
 use web_time::{Duration, Instant};
 
-use bevy::log::{debug, info};
+use bevy::log::debug;
 /*
 
 This Sink will send events to another thread that will constantly poll/flush command out to the synth.
@@ -217,7 +217,7 @@ impl Future for SinkTask {
         {
             let message = self.queue.pop_front().unwrap();
 
-            info!(
+            debug!(
                 "({}) {:?}",
                 message.command.channel(),
                 message.command.event()

--- a/bevy_midix/src/synth/sink/task.rs
+++ b/bevy_midix/src/synth/sink/task.rs
@@ -19,7 +19,7 @@ use midix::prelude::*;
 
 use crate::song::SongId;
 
-use super::{SinkCommand, SongType, commands::InnerCommand};
+use super::{SinkCommand, commands::InnerCommand};
 
 #[derive(Default)]
 pub struct CommandQueue(VecDeque<InnerCommand>);
@@ -162,7 +162,8 @@ impl Future for SinkTask {
                     self.queue_commands(None, iter::once(event), elapsed);
                 }
                 SinkCommand::NewSong {
-                    song_type,
+                    id,
+                    looped,
                     mut commands,
                 } => {
                     if commands.is_empty() {
@@ -171,13 +172,11 @@ impl Future for SinkTask {
                     commands.sort_by_key(|m| m.timestamp);
 
                     new_messages_pushed = true;
-                    if let SongType::Identified { id, looped } = song_type {
-                        if looped {
-                            self.keep_looping(id, commands.clone());
-                        }
+                    if looped {
+                        self.keep_looping(id, commands.clone());
                     }
 
-                    self.queue_commands(song_type.id(), commands, elapsed);
+                    self.queue_commands(Some(id), commands, elapsed);
                 }
                 SinkCommand::Stop {
                     song_id,

--- a/bevy_midix/src/synth/sink/task.rs
+++ b/bevy_midix/src/synth/sink/task.rs
@@ -2,6 +2,7 @@
 use std::time::{Duration, Instant};
 use std::{
     collections::VecDeque,
+    iter,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -109,7 +110,7 @@ impl SinkTask {
         })
     }
 
-    // song commands should already be sorted.
+    // song commands already be sorted, or should sort.
     //
     // elapsed is in micros
     fn queue_commands(
@@ -151,6 +152,13 @@ impl Future for SinkTask {
             },
         } {
             match messages {
+                SinkCommand::PlayEvent(event) => {
+                    // we will always sort. there is no guarantee that events after this aren't before/after this event.
+                    //
+                    // However, there could be a performance optimization here.
+                    new_messages_pushed = true;
+                    self.queue_commands(None, iter::once(event), elapsed);
+                }
                 SinkCommand::NewSong {
                     song_type,
                     mut commands,


### PR DESCRIPTION
See commit details for changes

- Synth::handle_event -> Synth::push_event is a big one
- SynthParams synth_event_reader now takes in a `SynthEventOpt` enum over a bool (will you handle event reading yourself, or should I?)