### PR TITLE
Fix pitch bend conversions

### DIFF
--- a/midix/tests/pitch_bend.rs
+++ b/midix/tests/pitch_bend.rs
@@ -1,0 +1,42 @@
+use midix::PitchBend;
+
+#[test]
+fn create_pitch_bend_event() {
+    let pb = PitchBend::from_f32(0.0);
+    assert_eq!(pb.value(), PitchBend::MID_BYTES);
+    let pb = PitchBend::from_f64(0.0);
+    assert_eq!(pb.value(), PitchBend::MID_BYTES);
+    let pb = PitchBend::from_int(0);
+    assert_eq!(pb.value(), PitchBend::MID_BYTES);
+}
+#[test]
+fn create_negative_pitch_bend_event() {
+    let pb = PitchBend::from_f32(-0.1);
+    assert_eq!(
+        pb.value(),
+        PitchBend::MID_BYTES - (PitchBend::MID_BYTES as f32 * 0.1) as u16
+    );
+    let pb = PitchBend::from_f64(-0.1);
+    assert_eq!(
+        pb.value(),
+        PitchBend::MID_BYTES - (PitchBend::MID_BYTES as f32 * 0.1) as u16
+    );
+    let pb = PitchBend::from_int(-82);
+    assert_eq!(pb.value(), PitchBend::MID_BYTES - 82);
+}
+#[test]
+fn pitch_bend_round_trip() {
+    for value in 0..PitchBend::MAX_VALUE {
+        let pb = PitchBend::from_u16(value);
+        assert_eq!(pb.value(), value);
+        let lsb = pb.lsb();
+        let msb = pb.msb();
+        let pb2 = PitchBend::from_bits_unchecked((lsb as u16) << 8 | msb as u16);
+        assert_eq!(pb2.value(), value);
+    }
+    assert_eq!(PitchBend::from_f32(0.5).as_f32(), 0.5);
+    assert_eq!(PitchBend::from_f32(0.875).as_f32(), 0.875);
+    assert_eq!(PitchBend::from_f32(-1.1).as_f32(), -1.0);
+    assert_eq!(PitchBend::from_f64(-0.5).as_f64(), -0.5);
+    assert_eq!(PitchBend::from_int(-200).as_int(), -200);
+}


### PR DESCRIPTION
Hi! I needed very exact pitch bend messages and noticed the pitch bend parsing was off.

The culprit was that PitchBend treated the bytes as 6 bits + 8 bits whereas the pitch bend midi message's data bytes are [7bits + 7bits](https://midi.org/summary-of-midi-1-0-messages). I also added a from_u16 method which correctly converts a normal u16 to the pitch bend bytes and tests to see that all conversions are working.

I would probably deprecate the `from_bits` and `from_bits_unchecked` methods since they are not used anywhere in the library and IMO slightly more confusing than using `PitchBend::new` directly, and I can't see a situation where you'd parse a u16 instead of two u8. 